### PR TITLE
feat(package): add simple +row +col buttons

### DIFF
--- a/src/components/TableComponent.tsx
+++ b/src/components/TableComponent.tsx
@@ -217,14 +217,36 @@ const TableComponent = (props: TableProps & { rowType?: string }) => {
       <Box>
         <Flex justify="flex-end">
           {value?.rows?.length && (
-            <TableMenu
-              addColumns={addColumns}
-              addColumnAt={addColumnAt}
-              addRows={addRows}
-              addRowAt={addRowAt}
-              remove={confirmRemoveTable}
-              placement="left"
-            />
+            <Inline space={1}>
+              <Button
+                fontSize={1}
+                padding={2}
+                icon={AddIcon}
+                text="Row"
+                mode="ghost"
+                onClick={() => {
+                  addRows(1);
+                }}
+              />
+              <Button
+                fontSize={1}
+                padding={2}
+                icon={AddIcon}
+                text="Column"
+                mode="ghost"
+                onClick={() => {
+                  addColumns(1);
+                }}
+              />
+              <TableMenu
+                addColumns={addColumns}
+                addColumnAt={addColumnAt}
+                addRows={addRows}
+                addRowAt={addRowAt}
+                remove={confirmRemoveTable}
+                placement="left"
+              />
+            </Inline>
           )}
         </Flex>
       </Box>


### PR DESCRIPTION
Checking the example gif in the readme shows some simple +1 Row and +1 Column buttons, but the actual package had that functionality hidden behind 3 modals and an increment/decrement input box. 

This change reduces the number of clicks the user has to perform in order to create a new table on the fly.