### PR TITLE
fix(deps): allow studio v5 in peer deps ranges

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -46,7 +46,7 @@
       },
       "peerDependencies": {
         "react": "^18 || ^19",
-        "sanity": "^3.0.0 || ^4.0.0"
+        "sanity": "^3.0.0 || ^4.0.0 || ^5.0.0"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
   },
   "peerDependencies": {
     "react": "^18 || ^19",
-    "sanity": "^3.0.0 || ^4.0.0"
+    "sanity": "^3.0.0 || ^4.0.0 || ^5.0.0"
   },
   "engines": {
     "node": ">=18"


### PR DESCRIPTION
### Description
This pull request updates the peer dependencies to support Sanity version 5.x, allowing the plugin to work with the latest major version of Sanity Studio while maintaining backward compatibility with versions 3.x and 4.x.
